### PR TITLE
Update testthat to V3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
 Suggests: 
     covr,
     spelling,
-    testthat
+    testthat (>= 3.0.0)
 RdMacros: 
     lifecycle
 Encoding: UTF-8
@@ -34,3 +34,4 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
+Config/testthat/edition: 3

--- a/tests/testthat/test-aaa-deprecated.R
+++ b/tests/testthat/test-aaa-deprecated.R
@@ -1,4 +1,4 @@
 test_that("check_flob", {
-  expect_null(check_flob(flob_old, old = TRUE))
-  expect_invisible(check_flob(flob_old, old = TRUE))
+  expect_null(chk_flob(flob_old, old = TRUE))
+  expect_invisible(chk_flob(flob_old, old = TRUE))
 })

--- a/tests/testthat/test-flobr.R
+++ b/tests/testthat/test-flobr.R
@@ -70,7 +70,7 @@ test_that("package with pdf", {
   flob2 <- flob(file.path(tempdir(), paste("flobr", "pdf", sep = ".")))
   expect_identical(flob_ext(flob2), flob_ext(flob))
   expect_identical(flob_name(flob2), flob_name(flob))
-  expect_equivalent(flob2, flob)
+  expect_equal(flob2, flob, ignore_attr = TRUE)
 })
 
 test_that("slob arg works", {


### PR DESCRIPTION
- updated description to use version 3 of testthat
- did not resolve warning around `chkor` 
- will need to be fixed before we fully deprecate chkor or this function will fail